### PR TITLE
I've fixed the YAML parsing errors in your tests and installer.

### DIFF
--- a/engine/tool_executor.js
+++ b/engine/tool_executor.js
@@ -24,13 +24,12 @@ async function getManifest() {
   }
   const fileContent = await fs.readFile(MANIFEST_PATH, "utf8");
 
-  // --- FIX: Use the first capture group (the actual YAML) from the regex match ---
   const yamlMatch = fileContent.match(/```(?:yaml|yml)\n([\s\S]*?)\s*```/);
-  if (!yamlMatch || !yamlMatch) {
+  if (!yamlMatch) {
     throw new Error(`Could not parse YAML from manifest file: ${MANIFEST_PATH}`);
   }
-
-  agentManifest = yaml.load(yamlMatch);
+  // yamlMatch[1] is the actual YAML content
+  agentManifest = yaml.load(yamlMatch[1]);
   return agentManifest;
 }
 

--- a/installer/install.js
+++ b/installer/install.js
@@ -14,8 +14,7 @@ const CWD = process.cwd();
 
 function parseAgentConfig(content) {
   // Use the first capture group (the actual YAML) from the regex match
-  // Loosened the regex to not require a closing ``` since it seems to get truncated on read
-  const yamlMatch = content.match(/```(?:yaml|yml)\n([\s\S]*)/);
+  const yamlMatch = content.match(/```(?:yaml|yml)\n([\s\S]*?)\s*```/);
   if (!yamlMatch) return null;
   try {
     // yamlMatch[1] is the actual YAML content
@@ -72,8 +71,7 @@ async function configureIde(coreSourceDir) {
   const manifestPath = path.join(coreSourceDir, "system_docs", "02_Agent_Manifest.md");
   const manifestContent = await fs.readFile(manifestPath, "utf8");
   // Use the first capture group (the actual YAML) from the regex match
-  // Loosened the regex to not require a closing ``` since it seems to get truncated on read
-  const yamlMatch = manifestContent.match(/```(?:yaml|yml)\n([\s\S]*)/);
+  const yamlMatch = manifestContent.match(/```(?:yaml|yml)\n([\s\S]*?)\s*```/);
   if (!yamlMatch) {
     throw new Error(`Could not parse YAML from manifest file: ${manifestPath}`);
   }


### PR DESCRIPTION
I found that the `tool_executor` and `installer` scripts were failing to parse YAML content embedded in markdown files. Here are the corrections I made:

- In `engine/tool_executor.js`, I adjusted the code to pass the correct captured group (`yamlMatch[1]`) to the YAML parser, rather than the entire regex match object.

- In `installer/install.js`, I updated a loose regex to be more strict by requiring a closing markdown fence. This prevents parsing errors and makes it consistent with the logic in the tool executor.

These changes resolve the test failures in `tests/unit/tool_executor.test.js` and prevent the errors and warnings that occurred during the `npx Stigmergy install` command.