### PR TITLE
fix(installer): Add start script and command

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 // --------------------------------------------------------------------
 import { run as runInstaller } from "../installer/install.js";
+import { main as startEngine } from "../engine/server.js";
 import { runBuilder } from "../builder/prompt_builder.js";
 
 const program = new Command();
@@ -39,6 +40,13 @@ program
     }
     // ---------------------------------------------------------
     await runBuilder(options);
+  });
+
+program
+  .command("start")
+  .description("Starts the Stigmergy engine server.")
+  .action(async () => {
+    await startEngine();
   });
 
 async function main() {

--- a/engine/server.js
+++ b/engine/server.js
@@ -123,7 +123,7 @@ export class Engine {
 
 const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
 
-async function main() {
+export async function main() {
   // --- FIX: Instantiate the engine HERE, inside the main execution block ---
   const engine = new Engine();
 

--- a/installer/install.js
+++ b/installer/install.js
@@ -148,6 +148,24 @@ async function configureIde(coreSourceDir) {
   await fs.writeFile(path.join(CWD, ".roomodes"), fileContent, "utf8");
 }
 
+async function addStartScript() {
+  const packageJsonPath = path.join(CWD, "package.json");
+  if (!(await fs.pathExists(packageJsonPath))) {
+    console.warn(
+      chalk.yellow(
+        `\nWarning: Could not find package.json. Please add the following script to your package.json manually:\n  "stigmergy:start": "stigmergy start"`
+      )
+    );
+    return;
+  }
+  const packageJson = await fs.readJson(packageJsonPath);
+  if (!packageJson.scripts) {
+    packageJson.scripts = {};
+  }
+  packageJson.scripts["stigmergy:start"] = "stigmergy start";
+  await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
+}
+
 export async function run() {
   const spinner = ora("🚀 Initializing Stigmergy...").start();
   try {
@@ -165,6 +183,10 @@ export async function run() {
     spinner.text = "Configuring IDE integration...";
     await configureIde(CORE_SOURCE_DIR);
     spinner.succeed("IDE integration configured in .roomodes");
+
+    spinner.text = "Adding start script to package.json...";
+    await addStartScript();
+    spinner.succeed("Start script added to package.json.");
 
     console.log(chalk.bold.green("\n✅ Stigmergy installation complete!"));
     console.log(chalk.cyan("Next steps:"));


### PR DESCRIPTION
The stigmergy installer was instructing you to run `npm run stigmergy:start` but was not adding the script to the project's `package.json`.

This change introduces the following fixes:
- A new `stigmergy start` command is added to the CLI to launch the engine.
- The installer now automatically adds the `stigmergy:start` script to your `package.json`.
- The `main` function in `engine/server.js` is now exported to be callable from the CLI.