### PR TITLE
fix(code-intelligence): Resolve `traverse is not a function` error

### DIFF
--- a/services/code_intelligence_service.js
+++ b/services/code_intelligence_service.js
@@ -3,7 +3,8 @@ import fs from "fs-extra";
 import path from "path";
 import { glob } from "glob";
 import * as babelParser from "@babel/parser";
-import traverse from "@babel/traverse";
+import _traverse from "@babel/traverse";
+const traverse = _traverse.default;
 
 class CodeIntelligenceService {
   constructor() {
@@ -234,7 +235,8 @@ class CodeIntelligenceService {
     if (!this.driver) {
       return {
         success: false,
-        error: "Neo4j driver not initialized. Check your .env credentials (NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD).",
+        error:
+          "Neo4j driver not initialized. Check your .env credentials (NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD).",
       };
     }
 


### PR DESCRIPTION
The `code_intelligence_service.js` was using `import traverse from "@babel/traverse";` which is incorrect for the version of `@babel/traverse` being used, as it doesn't have a default export in a way that's compatible with ES modules. This was causing a `TypeError: traverse is not a function` when the service was being initialized.

This commit changes the import to `import _traverse from "@babel/traverse"; const traverse = _traverse.default;` which correctly imports the traverse function. This resolves the startup error.