### PR TITLE
fix: Correctly import babel/traverse in CodeIntelligenceService

### DIFF
--- a/services/code_intelligence_service.js
+++ b/services/code_intelligence_service.js
@@ -3,8 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import { glob } from "glob";
 import * as babelParser from "@babel/parser";
-import _traverse from "@babel/traverse";
-const traverse = _traverse.default;
+import traverse from "@babel/traverse";
 
 class CodeIntelligenceService {
   constructor() {

--- a/stigmergy.log
+++ b/stigmergy.log
@@ -1,0 +1,3 @@
+
+> @randy888chan/stigmergy@2.1.0 stigmergy:start
+> stigmergy start


### PR DESCRIPTION
The previous import for `@babel/traverse` was causing a `TypeError: traverse is not a function` because it was not correctly handling the module's export. This commit changes the import to the correct format for an ES module, which resolves the test failure in `code_intelligence_service.test.js`.