### PR TITLE
feat: Implement granular multi-provider URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,30 @@
-# --- Tiered AI Provider API Keys ---
-# The system uses a tiered model defined in stigmergy.config.js.
-# It is recommended to use a service like OpenRouter.ai to access all models
-# through a single API key, which you can place in the OPENROUTER_API_KEY variable.
+# .env.example
 
-# Key for S-Tier, A-Tier, etc. (if using a unified provider like OpenRouter)
+# --- Multi-Provider API Keys & Base URLs ---
+# Fill in the API keys and Base URLs for the LLM providers you want to use.
+# The system will select the correct set of credentials based on the agent's
+# "model_tier" as defined in stigmergy.config.js.
+
+# -- Provider: Deepseek --
+DEEPSEEK_API_KEY=
+DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+
+# -- Provider: Google (for Gemini models) --
+GOOGLE_API_KEY=
+# Note: Google's SDK often handles the URL, but it can be specified if needed.
+# GOOGLE_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+
+# -- Provider: Mistral AI --
+MISTRAL_API_KEY=
+MISTRAL_BASE_URL=https://api.mistral.ai/v1
+
+# -- Provider: Kimi (Moonshot AI) --
+KIMI_API_KEY=
+KIMI_BASE_URL=https://api.moonshot.cn/v1
+
+# -- Provider: OpenRouter (as an aggregator) --
 OPENROUTER_API_KEY=
-
-# You can also use different keys for different providers if you configure it in stigmergy.config.js
-# OPENAI_API_KEY=
-# DEEPSEEK_API_KEY=
-
-# The base URL for the unified provider.
-AI_API_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
 
 # --- Research Tool Configuration ---

--- a/stigmergy.config.js
+++ b/stigmergy.config.js
@@ -7,21 +7,30 @@ const config = {
     neo4j: "auto", // Options: 'required', 'auto', 'memory'
   },
   model_tiers: {
-    s_tier: {
+    s_tier: { // Strategic/Reasoning -> Using Deepseek
+      provider: "deepseek",
+      api_key_env: "DEEPSEEK_API_KEY",
+      base_url_env: "DEEPSEEK_BASE_URL",
+      model_name: "deepseek/deepseek-chat",
+    },
+    a_tier: { // Advanced/Execution -> Using Gemini via OpenRouter for compatibility
       provider: "openrouter",
-      model_name: "anthropic/claude-3-opus",
-      provider_env_key: "OPENROUTER_API_KEY",
+      api_key_env: "OPENROUTER_API_KEY",
+      base_url_env: "OPENROUTER_BASE_URL",
+      model_name: "google/gemini-pro-1.5",
     },
-    a_tier: {
-      provider: "openai",
-      model_name: "gpt-4o",
-      provider_env_key: "OPENAI_API_KEY",
+    b_tier: { // Basic/Utility -> Using Mistral
+      provider: "mistral",
+      api_key_env: "MISTRAL_API_KEY",
+      base_url_env: "MISTRAL_BASE_URL",
+      model_name: "mistralai/mistral-7b-instruct",
     },
-    b_tier: {
-      provider: "openrouter",
-      model_name: "anthropic/claude-3-haiku",
-      provider_env_key: "OPENROUTER_API_KEY",
-    },
+    c_tier: { // Specialized/Long-Context -> Using Kimi
+        provider: "kimi",
+        api_key_env: "KIMI_API_KEY",
+        base_url_env: "KIMI_BASE_URL",
+        model_name: "moonshot-v1-128k", // Using a more realistic model name
+    }
   },
 };
 

--- a/tests/integration/providers.test.js
+++ b/tests/integration/providers.test.js
@@ -1,0 +1,103 @@
+import { getModelForTier, _resetProviderInstances } from '../../ai/providers.js';
+import { createOpenAI } from '@ai-sdk/openai';
+import config from '../../stigmergy.config.js';
+
+// Mock the entire stigmergy.config.js module
+jest.mock('../../stigmergy.config.js', () => ({
+  __esModule: true, // This is important for ES modules
+  default: {
+    model_tiers: {
+      deepseek_tier: {
+        provider: 'deepseek',
+        api_key_env: 'DEEPSEEK_TEST_KEY',
+        base_url_env: 'DEEPSEEK_TEST_URL',
+        model_name: 'deepseek/deepseek-chat',
+      },
+      openrouter_tier: {
+        provider: 'openrouter',
+        api_key_env: 'OPENROUTER_TEST_KEY',
+        base_url_env: 'OPENROUTER_TEST_URL',
+        model_name: 'google/gemini-pro-1.5',
+      },
+      mistral_tier: {
+        provider: 'mistral',
+        api_key_env: 'MISTRAL_TEST_KEY',
+        base_url_env: 'MISTRAL_TEST_URL',
+        model_name: 'mistralai/mistral-7b-instruct',
+      },
+    },
+  },
+}));
+
+// Mock the createOpenAI function to inspect its calls
+jest.mock('@ai-sdk/openai', () => ({
+  createOpenAI: jest.fn(),
+}));
+
+describe('Multi-provider configuration', () => {
+  beforeEach(() => {
+    // Reset the provider cache before each test
+    _resetProviderInstances();
+
+    // Reset mocks before each test
+    createOpenAI.mockClear();
+
+    // Mock environment variables
+    process.env.DEEPSEEK_TEST_KEY = 'deepseek-key-123';
+    process.env.DEEPSEEK_TEST_URL = 'https://api.deepseek.com/v1';
+    process.env.OPENROUTER_TEST_KEY = 'openrouter-key-456';
+    process.env.OPENROUTER_TEST_URL = 'https://openrouter.ai/api/v1';
+    process.env.MISTRAL_TEST_KEY = 'mistral-key-789';
+    process.env.MISTRAL_TEST_URL = 'https://api.mistral.ai/v1';
+
+    // Mock the return value of createOpenAI
+    const mockProvider = jest.fn().mockReturnValue('mock-model-instance');
+    createOpenAI.mockReturnValue(mockProvider);
+  });
+
+  afterEach(() => {
+    // Clean up environment variables
+    delete process.env.DEEPSEEK_TEST_KEY;
+    delete process.env.DEEPSEEK_TEST_URL;
+    delete process.env.OPENROUTER_TEST_KEY;
+    delete process.env.OPENROUTER_TEST_URL;
+    delete process.env.MISTRAL_TEST_KEY;
+    delete process.env.MISTRAL_TEST_URL;
+  });
+
+  it('should initialize Deepseek provider with correct key and URL', () => {
+    getModelForTier('deepseek_tier');
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'deepseek-key-123',
+      baseURL: 'https://api.deepseek.com/v1',
+    });
+  });
+
+  it('should initialize OpenRouter provider with correct key and URL', () => {
+    getModelForTier('openrouter_tier');
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'openrouter-key-456',
+      baseURL: 'https://openrouter.ai/api/v1',
+    });
+  });
+
+  it('should initialize Mistral provider with correct key and URL', () => {
+    getModelForTier('mistral_tier');
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'mistral-key-789',
+      baseURL: 'https://api.mistral.ai/v1',
+    });
+  });
+
+  it('should use the same provider instance for the same tier', () => {
+    getModelForTier('deepseek_tier');
+    getModelForTier('deepseek_tier');
+    expect(createOpenAI).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a new provider instance for a different tier', () => {
+    getModelForTier('deepseek_tier');
+    getModelForTier('openrouter_tier');
+    expect(createOpenAI).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/integration/research_reflection.test.js
+++ b/tests/integration/research_reflection.test.js
@@ -1,6 +1,11 @@
+process.env.DEEPSEEK_API_KEY = "test_key";
+process.env.DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
 process.env.OPENROUTER_API_KEY = "test_key";
-process.env.AI_API_KEY = "test";
-process.env.AI_MODEL = "test";
+process.env.OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+process.env.MISTRAL_API_KEY = "test_key";
+process.env.MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
+process.env.KIMI_API_KEY = "test_key";
+process.env.KIMI_BASE_URL = "https://api.moonshot.cn/v1";
 process.env.FIRECRAWL_KEY = "test";
 import { jest } from "@jest/globals";
 import { researchGraph } from "../../engine/research_graph.js";

--- a/tests/metis.test.js
+++ b/tests/metis.test.js
@@ -17,7 +17,7 @@ describe('Metis to Guardian Self-Improvement Workflow', () => {
   test('should allow @metis to propose a change and correctly trigger the @guardian agent', async () => {
     // Arrange: Simulate the proposal that @metis would create
     const proposal = {
-      file_path: ".stigmergy-core/agents/debugger.md",
+      file_path: `${global.StigmergyConfig.core_path}/agents/debugger.md`,
       new_content: "agent: id: debugger\n...",
       reason: "Analysis of failure patterns indicates the debugger needs an updated protocol for database errors.",
     };
@@ -50,7 +50,7 @@ describe('Metis to Guardian Self-Improvement Workflow', () => {
   test('should throw an error if propose_change is called with missing arguments', async () => {
     // Arrange: An incomplete proposal from @metis
     const incompleteProposal = {
-      file_path: ".stigmergy-core/agents/debugger.md",
+      file_path: `${global.StigmergyConfig.core_path}/agents/debugger.md`,
       // new_content is missing
       reason: "A reason without content.",
     };


### PR DESCRIPTION
This change updates the application to support multiple LLM providers, each with its own unique API key and base URL. This provides a more flexible and robust configuration for using different LLM providers.

The following changes were made:
- The `.env.example` file was updated to include separate sections for each provider's API key and base URL.
- The `stigmergy.config.js` file was updated to reference the new environment variables for both the API key and the base URL for each tier.
- The `ai/providers.js` file was updated with new logic to correctly read the provider-specific API key and base URL from the environment and initialize a unique provider instance for each.
- A new integration test file, `tests/integration/providers.test.js`, was added to verify the new multi-provider logic.
- The `tests/metis.test.js` file was updated to use a dynamic path for the `.stigmergy-core` directory, preventing it from corrupting the real core directory during tests.
- The `tests/integration/research_reflection.test.js` file was updated to set the new required environment variables.