### PR TITLE
The Stigmergy Project Dashboard was failing to load data due to a 404…

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -97,7 +97,7 @@
     </div>
 
     <script>
-        const API_ENDPOINT = '/dashboard/state';
+        const API_ENDPOINT = '/state';
 
         async function fetchData() {
             try {


### PR DESCRIPTION
… error. This was caused by the frontend making a request to an incorrect API endpoint (`/dashboard/state` instead of `/state`).

This commit corrects the `API_ENDPOINT` constant in `dashboard/public/index.html` to point to the correct `/state` URL, resolving the 404 error and allowing the dashboard to load its data correctly.