### PR TITLE
Fix: Ensure .env file is loaded from the correct project directory

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -1,8 +1,8 @@
+import "dotenv/config";
 import express from "express";
 import http from "http";
 import { WebSocketServer } from "ws";
 import chalk from "chalk";
-import "dotenv/config.js";
 import { fileURLToPath } from 'url';
 import path from 'path';
 

--- a/src/bootstrap/system_validator.js
+++ b/src/bootstrap/system_validator.js
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";


### PR DESCRIPTION
This commit fixes a critical bug where the Stigmergy engine and CLI tools would not load the `.env` file from the directory where they were being executed. This caused failures in services that require environment variables, such as the Neo4j connection.

The fix involves adding `dotenv/config` to the top of the two main entry points:
- `engine/server.js` (for the `stigmergy start` command)
- `src/bootstrap/system_validator.js` (for the `stigmergy validate` command)

This ensures that environment variables are loaded before any other code that might depend on them.

Note: The test suite for this repository is currently in a brittle state and fails due to issues with its setup and missing fixtures. This commit addresses the core runtime issue as requested.