### PR TITLE
fix: Correctly instantiate CoreBackup in SystemValidator

### DIFF
--- a/src/bootstrap/system_validator.js
+++ b/src/bootstrap/system_validator.js
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import os from "os";
 import { Neo4jValidator } from "../../engine/neo4j_validator.js";
-import coreBackup from "../../services/core_backup.js";
+import { CoreBackup } from "../../services/core_backup.js";
 
 /**
  * Validates the health of the entire Stigmergy system.
@@ -11,6 +11,7 @@ import coreBackup from "../../services/core_backup.js";
 export class SystemValidator {
   constructor() {
     this.results = {};
+    this.coreBackup = new CoreBackup();
   }
 
   async comprehensiveCheck() {
@@ -63,7 +64,7 @@ export class SystemValidator {
         return { success: false, error: "No backup files found." };
       }
       const latestBackup = path.join(backupDir, backups[backups.length - 1]);
-      const verification = await coreBackup.verifyBackup(latestBackup);
+      const verification = await this.coreBackup.verifyBackup(latestBackup);
       return verification;
     } catch (error) {
       return { success: false, error: "Backup validation failed: " + error.message };

--- a/tests/unit/system_validator.test.js
+++ b/tests/unit/system_validator.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// 1. Create mock functions that are in scope for the whole file
+const mockVerifyBackup = mock(() => Promise.resolve({ success: true }));
+const mockNeo4jValidate = mock(() => Promise.resolve({ success: true }));
+const mockFsExistsSync = mock(() => true);
+const mockFsReadDir = mock(() => Promise.resolve(["backup1.tar.gz"]));
+
+// 2. Mock the modules and use the functions from step 1
+mock.module("../../services/core_backup.js", () => ({
+  CoreBackup: class {
+    verifyBackup = mockVerifyBackup;
+  },
+}));
+
+mock.module("../../engine/neo4j_validator.js", () => ({
+  Neo4jValidator: {
+    validate: mockNeo4jValidate,
+  },
+}));
+
+// fs-extra is a CJS module, so mocking the default export is key.
+mock.module("fs-extra", () => ({
+  default: {
+    existsSync: mockFsExistsSync,
+    readdir: mockFsReadDir,
+  },
+}));
+
+// 3. Now that mocks are set up, import the system under test
+import { SystemValidator } from "../../src/bootstrap/system_validator.js";
+
+describe("SystemValidator", () => {
+  let validator;
+
+  beforeEach(() => {
+    // 4. Reset mocks before each test using the handles from step 1
+    mockVerifyBackup.mockClear();
+    mockNeo4jValidate.mockClear();
+    mockFsExistsSync.mockClear();
+    mockFsReadDir.mockClear();
+
+    // Set default behaviors for a "happy path" test
+    mockFsExistsSync.mockReturnValue(true);
+    mockFsReadDir.mockResolvedValue(["backup1.tar.gz"]);
+    mockVerifyBackup.mockResolvedValue({ success: true });
+    mockNeo4jValidate.mockResolvedValue({ success: true });
+
+    // Instantiate the validator
+    validator = new SystemValidator();
+  });
+
+  it("should run comprehensiveCheck and report success when all checks pass", async () => {
+    const results = await validator.comprehensiveCheck();
+    expect(results.core.success).toBe(true);
+    expect(results.neo4j.success).toBe(true);
+    expect(results.backups.success).toBe(true);
+    expect(results.governance.success).toBe(true);
+  });
+
+  it("validateBackups should return success when backups are valid", async () => {
+    const result = await validator.validateBackups();
+    expect(result.success).toBe(true);
+    expect(mockVerifyBackup).toHaveBeenCalled();
+  });
+
+  it("validateBackups should return an error if the backup directory does not exist", async () => {
+    // Override the default mock behavior for this specific test
+    mockFsExistsSync.mockReturnValueOnce(false);
+    const result = await validator.validateBackups();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Backup directory not found.");
+  });
+
+  it("validateBackups should return an error if there are no backup files", async () => {
+    mockFsReadDir.mockResolvedValue([]);
+    const result = await validator.validateBackups();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("No backup files found.");
+  });
+
+  it("comprehensiveCheck should report failure if any check fails", async () => {
+    // Make the backup check fail
+    mockVerifyBackup.mockResolvedValue({ success: false, error: "Backup corrupted" });
+
+    const results = await validator.comprehensiveCheck();
+    expect(results.backups.success).toBe(false);
+
+    const hasFailures = Object.values(results).some((r) => !r.success);
+    expect(hasFailures).toBe(true);
+  });
+});


### PR DESCRIPTION
The `SystemValidator` class was attempting to call `verifyBackup` on the `CoreBackup` class directly, as if it were a static method. However, `CoreBackup` is a class that must be instantiated before its methods can be used.

This commit fixes the bug by:
1. Importing the `CoreBackup` class instead of a non-existent default export.
2. Instantiating `CoreBackup` in the `SystemValidator`'s constructor.
3. Calling `verifyBackup` on the `this.coreBackup` instance.

Additionally, a new test file `tests/unit/system_validator.test.js` has been added with comprehensive tests for the `SystemValidator`, including mocks for its dependencies, to verify the fix and prevent future regressions.