### PR TITLE
feat: Implement plan-driven dispatcher workflow

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -1,0 +1,1 @@
+console.log('Hello from the dispatcher!');

--- a/tools/file_system.js
+++ b/tools/file_system.js
@@ -16,18 +16,20 @@ const SAFE_DIRECTORIES = config.security?.allowedDirs || [
   "system-proposals",
 ];
 
-export function resolvePath(filePath, fs = defaultFs) {
+export function resolvePath(filePath, projectRoot, fs = defaultFs) {
   if (!filePath || typeof filePath !== "string") {
     throw new Error("Invalid file path provided");
   }
+
+  const rootDir = projectRoot || process.cwd();
 
   // Enhanced path traversal check
   if (filePath.split(path.sep).includes("..")) {
     throw new Error(`Security violation: Path traversal attempt (${filePath})`);
   }
 
-  const resolved = path.resolve(process.cwd(), filePath);
-  const relative = path.relative(process.cwd(), resolved);
+  const resolved = path.resolve(rootDir, filePath);
+  const relative = path.relative(rootDir, resolved);
 
   // Block path traversal after resolution (double check)
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
@@ -61,25 +63,25 @@ export function resolvePath(filePath, fs = defaultFs) {
   return resolved;
 }
 
-export async function readFile({ path: filePath, fs = defaultFs }) {
-  const safePath = resolvePath(filePath, fs);
+export async function readFile({ path: filePath, projectRoot, fs = defaultFs }) {
+  const safePath = resolvePath(filePath, projectRoot, fs);
   return fs.readFile(safePath, "utf-8");
 }
 
-export async function writeFile({ path: filePath, content, fs = defaultFs }) {
-  const safePath = resolvePath(filePath, fs);
+export async function writeFile({ path: filePath, content, projectRoot, fs = defaultFs }) {
+  const safePath = resolvePath(filePath, projectRoot, fs);
   await fs.ensureDir(path.dirname(safePath));
   await fs.writeFile(safePath, content);
   return `File ${filePath} written successfully`;
 }
 
-export async function listFiles({ directory, fs = defaultFs }) {
-  const safePath = resolvePath(directory, fs);
+export async function listFiles({ directory, projectRoot, fs = defaultFs }) {
+  const safePath = resolvePath(directory, projectRoot, fs);
   return glob("**/*", { cwd: safePath, nodir: true });
 }
 
-export async function appendFile({ path: filePath, content, fs = defaultFs }) {
-  const safePath = resolvePath(filePath, fs);
+export async function appendFile({ path: filePath, content, projectRoot, fs = defaultFs }) {
+  const safePath = resolvePath(filePath, projectRoot, fs);
   await fs.ensureDir(path.dirname(safePath));
   // The 'a' flag stands for "append"
   await fs.appendFile(safePath, content);

--- a/tools/system_tools.js
+++ b/tools/system_tools.js
@@ -15,8 +15,8 @@ export default (engine) => ({
     if (!newStatus) {
       throw new Error("The 'newStatus' argument is required for system.updateStatus.");
     }
-    // Note: We use the engine's stateManagerModule to call the function
-    await engine.stateManagerModule.updateStatus({ newStatus, message });
+    // Note: We use the engine's stateManager to call the function
+    await engine.stateManager.updateStatus({ newStatus, message });
     const confirmation = `System status successfully updated to ${newStatus}.`;
     console.log(`[System Tool] ${confirmation}`);
     return confirmation;

--- a/utils/sanitization.js
+++ b/utils/sanitization.js
@@ -17,6 +17,10 @@ const toolSchemas = {
   'shell.run': {
     command: z.string().min(1),
   },
+  'system.updateStatus': {
+    newStatus: z.string().min(1),
+    message: z.string().optional(),
+  },
   'stigmergy.task': {
     subagent_type: z.string().min(1),
     description: z.string().min(1),


### PR DESCRIPTION
Replaces the mock autonomous loop in `engine/server.js` with a real, plan-driven dispatcher workflow.

Key changes:
- Removes `runMockAutonomousLoop` and introduces a `runDispatcher` function that triggers the `@dispatcher` agent when the project status becomes `ENRICHMENT_PHASE`.
- Implements a new `triggerAgent` function that orchestrates the agent execution loop, including loading agent definitions, interacting with the LLM, and executing tool calls.
- Refactors `tool_executor.js` to dynamically generate tool schemas for the AI model and injects the `projectRoot` to make file system tools project-aware.
- Updates `utils/sanitization.js` with the missing schema for the `system.updateStatus` tool.
- Fixes a bug in `tools/system_tools.js` where `stateManagerModule` was used instead of `stateManager`.
- Overhauls the E2E test in `tests/e2e/full_workflow.test.js` to use dependency injection and a mock `streamText` function for robust, isolated testing of the new autonomous workflow.