### PR TITLE
feat: Implement human handoff tool and modernize Docker config

### DIFF
--- a/tests/integration/engine/human_handoff.test.js
+++ b/tests/integration/engine/human_handoff.test.js
@@ -1,0 +1,35 @@
+import { mock, describe, test, expect, beforeEach } from 'bun:test';
+import { Engine } from '../../../engine/server.js';
+import stateManager from '../../../src/infrastructure/state/GraphStateManager.js';
+import fs from 'fs-extra';
+import path from 'path';
+
+describe('Human Handoff Workflow', () => {
+  let engine;
+
+  beforeEach(() => {
+    mock.restore();
+    // We must instantiate the engine with the real state manager for this test.
+    engine = new Engine(stateManager);
+  });
+
+  test('Dispatcher should be able to call the request_human_approval tool', async () => {
+    // Spy on the engine's broadcastEvent method. This is our verification point.
+    const broadcastSpy = mock(engine.broadcastEvent);
+    engine.broadcastEvent = broadcastSpy;
+
+    // Simulate a tool call from the @dispatcher agent.
+    // We are calling the tool executor directly to isolate the test.
+    await engine.executeTool.execute(
+      'system.request_human_approval',
+      { message: 'Approve plan?', data: { content: 'plan details' } },
+      'dispatcher'
+    );
+
+    // Assert that the broadcast event was called with the correct payload.
+    expect(broadcastSpy).toHaveBeenCalledWith(
+      'human_approval_request',
+      { message: 'Approve plan?', data: { content: 'plan details' } }
+    );
+  });
+});

--- a/tools/system_tools.js
+++ b/tools/system_tools.js
@@ -6,20 +6,32 @@
 export default (engine) => ({
   /**
    * Updates the overall project status.
-   * @param {Object} args
-   * @param {string} args.newStatus - The new status for the project.
-   * @param {string} args.message - A descriptive message for the status change.
-   * @returns {Promise<string>} Confirmation of the status change.
    */
   updateStatus: async ({ newStatus, message }) => {
     if (!newStatus) {
       throw new Error("The 'newStatus' argument is required for system.updateStatus.");
     }
-    // Note: We use the engine's stateManager to call the function
     await engine.stateManager.updateStatus({ newStatus, message });
     const confirmation = `System status successfully updated to ${newStatus}.`;
     console.log(`[System Tool] ${confirmation}`);
     return confirmation;
+  },
+
+  /**
+   * Sends a structured request for human approval to the dashboard.
+   * This is the new tool for the dispatcher's "Human Handoff" protocol.
+   * @param {object} args
+   * @param {string} args.message - The question for the user (e.g., "Please approve this business plan.").
+   * @param {object} args.data - The data to be reviewed (e.g., the content of the business plan).
+   * @returns {Promise<string>} Confirmation message.
+   */
+  request_human_approval: async ({ message, data }) => {
+    if (!message || !data) {
+      throw new Error("The 'message' and 'data' arguments are required for system.request_human_approval.");
+    }
+    console.log(`[System Tool] Requesting human approval: ${message}`);
+    engine.broadcastEvent('human_approval_request', { message, data });
+    return "Request for human approval has been sent to the dashboard.";
   },
 
   /**

--- a/utils/sanitization.js
+++ b/utils/sanitization.js
@@ -21,6 +21,10 @@ const toolSchemas = {
     newStatus: z.string().min(1),
     message: z.string().optional(),
   },
+  'system.request_human_approval': {
+    message: z.string().min(1),
+    data: z.record(z.string(), z.any()),
+  },
   'stigmergy.task': {
     subagent_type: z.string().min(1),
     description: z.string().min(1),


### PR DESCRIPTION
This commit introduces the 'human handoff' feature and modernizes the project's Docker setup to be Bun-native.

Key changes include:
- Refactored `tools/system_tools.js` to a factory pattern to allow the injection of the `engine` instance.
- Added the new `system.request_human_approval` tool to facilitate human-in-the-loop workflows.
- Replaced the Node.js-based Dockerfile with a multi-stage, Bun-native version for improved efficiency and consistency.
- Added a validation schema for the new tool in `utils/sanitization.js`.
- Added a new integration test (`tests/integration/engine/human_handoff.test.js`) to verify the functionality of the new tool.
- Added `@happy-dom/global-registrator` as a dev dependency to fix the test environment.