### PR TITLE
fix(ai): Ensure OpenAI provider uses strict compatibility

### DIFF
--- a/ai/providers.js
+++ b/ai/providers.js
@@ -58,7 +58,8 @@ export function getModelForTier(tier = 'utility_tier', useCase = null, config) {
                 'deepseek',
                 'kimi',
                 'mistral',
-                'anthropic' // Assuming Anthropic is accessed via an OpenAI-compatible endpoint as per config
+                'anthropic', // Assuming Anthropic is accessed via an OpenAI-compatible endpoint as per config
+                'openai'
             ];
 
             // Apply strict compatibility for known providers or if the URL suggests it (e.g., OpenRouter).

--- a/tests/unit/ai/providers.test.js
+++ b/tests/unit/ai/providers.test.js
@@ -1,0 +1,44 @@
+import { test, expect, describe, mock } from 'bun:test';
+
+// Mock the external dependencies
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: mock(() => mock(() => 'mock-model')),
+}));
+
+// Dynamically import the module to be tested
+const { getAiProviders } = await import('../../../ai/providers.js');
+const { createOpenAI } = await import('@ai-sdk/openai');
+
+describe('AI Provider Configuration', () => {
+  test('should create OpenAI provider with strict compatibility', () => {
+    // 1. Arrange
+    const mockConfig = {
+      model_tiers: {
+        openai_reasoning: {
+          provider: 'openai',
+          model_name: 'o1-preview',
+          api_key_env: 'OPENAI_API_KEY',
+          base_url_env: null,
+        },
+      },
+    };
+
+    process.env.OPENAI_API_KEY = 'test-key';
+    const ai = getAiProviders(mockConfig);
+
+    // 2. Act
+    ai.getModelForTier('openai_reasoning');
+
+    // 3. Assert
+    expect(createOpenAI).toHaveBeenCalled();
+    const lastCall = createOpenAI.mock.calls[createOpenAI.mock.calls.length - 1];
+    expect(lastCall[0]).toEqual(
+      expect.objectContaining({
+        compatibility: 'strict',
+      })
+    );
+
+    // Cleanup
+    delete process.env.OPENAI_API_KEY;
+  });
+});


### PR DESCRIPTION
The `openAICompatibleProviders` array in `ai/providers.js` was missing 'openai'. This caused an inconsistency where tiers using the OpenAI provider were not created with the `compatibility: 'strict'` flag, unlike other OpenAI-compatible providers.

This change adds 'openai' to the array to ensure consistent and robust behavior, aligning with the Vercel AI SDK's best practices.

A new unit test has been added to verify that the `createOpenAI` function is called with the correct compatibility setting for the 'openai' provider.