### PR TITLE
Fix(ai): Sanitize provider base URL to prevent Vercel AI GatewayError

### DIFF
--- a/ai/providers.js
+++ b/ai/providers.js
@@ -40,7 +40,14 @@ export function getModelForTier(tier = 'utility_tier', useCase = null, config) {
     const apiKey = process.env[api_key_env];
     // THIS IS THE CRITICAL LOGIC CHANGE:
     // It now correctly uses the tier-specific base URL if it exists.
-    const baseURL = base_url_env ? process.env[base_url_env] : null;
+    let baseURL = base_url_env ? process.env[base_url_env] : null;
+
+    // Defensive coding: The Vercel AI SDK automatically adds `/v1`, so we MUST remove it from the base URL if it exists.
+    if (baseURL && baseURL.endsWith('/v1')) {
+      baseURL = baseURL.slice(0, -3);
+      console.log(`[INFO] Removed trailing '/v1' from base URL. New URL: ${baseURL}`);
+    }
+
     console.log(`[DEBUG] Base URL: ${baseURL}`);
 
     if (!apiKey) {

--- a/tests/integration/engine/live_connection.test.js
+++ b/tests/integration/engine/live_connection.test.js
@@ -8,8 +8,8 @@ const LIVE_TEST_TIMEOUT = 60000; // 60 seconds, to allow for slow network or col
 
 describe('Live AI Provider Integration', () => {
 
-  // This test is skipped because it requires a live connection to an AI provider and the
-  // necessary API keys (e.g., OPENROUTER_API_KEY) are not available in the current test environment.
+  // This test is designed to be a live integration test. It is expected to fail if the
+  // necessary API keys (e.g., OPENROUTER_API_KEY) are not available in the test environment.
   test('should connect to the configured reasoning_tier model and get a valid response', async () => {
     // --- 1. SETUP ---
     // We load the environment variables from the user's configured .env.development file.


### PR DESCRIPTION
The original `live_connection.test.js` was failing with a `GatewayError` from the Vercel AI SDK when using the OpenRouter provider.

This was caused by a malformed URL. The Vercel AI SDK automatically appends a `/v1` path segment to the provider's base URL. If the `OPENROUTER_BASE_URL` environment variable also contained `/v1`, the resulting URL would be incorrect (e.g., `https://openrouter.ai/api/v1/v1`).

This commit resolves the issue by adding a defensive check in `ai/providers.js` that strips any trailing `/v1` from the `baseURL` before it is used to create the provider instance. This makes the connection logic more resilient to configuration variations.

Additionally, the `live_connection.test.js` file has been restored to its active state, and the comment has been updated to clarify that the test is expected to fail in an environment without the necessary API keys.