### PR TITLE
refactor(ai): Return client and modelName from getModelForTier

### DIFF
--- a/engine/llm_adapter.js
+++ b/engine/llm_adapter.js
@@ -2,7 +2,8 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 
 export async function generateStructuredOutput(prompt, schema, ai, tier = 'utility_tier', config) {
-  const model = ai.getModelForTier(tier, null, config); // Pass config
+  const { client, modelName } = ai.getModelForTier(tier, null, config); // Pass config
+  const model = client(modelName);
   const { object } = await generateObject({
     model: model,
     prompt: prompt,
@@ -12,7 +13,8 @@ export async function generateStructuredOutput(prompt, schema, ai, tier = 'utili
 }
 
 export async function generateText(prompt, ai, tier = 'utility_tier', config) {
-  const model = ai.getModelForTier(tier, null, config); // Pass config
+  const { client, modelName } = ai.getModelForTier(tier, null, config); // Pass config
+  const model = client(modelName);
   // Assuming a simple text generation for now, not structured.
   // In a real scenario, you might use generateText from 'ai' or a similar function.
   const { text } = await generateObject({

--- a/engine/research_graph.js
+++ b/engine/research_graph.js
@@ -2,6 +2,7 @@ import { END, StateGraph } from "@langchain/langgraph";
 import * as research from "../tools/research.js";
 import { createGraphStore } from "../src/infrastructure/graph_db/graphStore.js";
 import { GraphStateManager } from "../src/infrastructure/state/GraphStateManager.js";
+import { generateText } from "ai";
 
 import config from "../stigmergy.config.js"; // Import config
 
@@ -28,14 +29,21 @@ const researchNode = async (state) => {
 
 const createReflectionNode = (aiProviders) => async (state) => {
   const { getModelForTier } = aiProviders;
-  const model = getModelForTier("reflection_tier", null, config); // Pass config
+  const { client, modelName } = getModelForTier("reflection_tier", null, config);
+  const model = client(modelName);
   const prompt = `You are a researcher. You have been given a topic and some initial research. Your job is to reflect on the research and determine if it is complete. If it is complete, respond with "true". Otherwise, respond with a list of new questions to research.\n\nTopic: ${state.topic}\nInitial Learning: ${state.initial_learning}\n`;
-  const response = await model.invoke(prompt);
+
+  const { text: response } = await generateText({
+    model,
+    prompt,
+  });
 
   if (response.toLowerCase().includes("true")) {
     return { is_done: true, final_report: `Research Report for: ${state.topic}\n${state.initial_learning}` };
   } else {
-    return { is_done: false, new_questions: response };
+    // Assuming the response is a list of questions separated by newlines
+    const new_questions = response.split('\n').filter(q => q.trim().length > 0);
+    return { is_done: false, new_questions };
   }
 };
 

--- a/engine/server.js
+++ b/engine/server.js
@@ -86,7 +86,13 @@ export class Engine {
                 console.log(chalk.blue(`[Engine] Agent loop turn ${turnCount}...`));
 
                 const streamTextFunc = this._test_streamText || streamText;
-                const model = this._test_streamText ? null : this.ai.getModelForTier('reasoning_tier');
+                let model;
+                if (this._test_streamText) {
+                    model = null;
+                } else {
+                    const { client, modelName } = this.ai.getModelForTier('reasoning_tier');
+                    model = client(modelName);
+                }
 
                 const { toolCalls, finishReason, text } = await streamTextFunc({
                     model,

--- a/engine/verification_system.js
+++ b/engine/verification_system.js
@@ -5,8 +5,9 @@ import { z } from 'zod';
 
 async function extractKeyTerms(content, prompt, aiProviders, config) {
   const { getModelForTier } = aiProviders;
+  const { client, modelName } = getModelForTier('b_tier', null, config);
   const { object } = await aiProviders.generateObject({
-    model: getModelForTier('b_tier', null, config), // Pass config
+    model: client(modelName), // Pass config
     prompt: `${prompt}
 ---
 DOCUMENT:

--- a/tests/mocks/ai-providers.js
+++ b/tests/mocks/ai-providers.js
@@ -1,20 +1,36 @@
-console.log("Loading tests/mocks/ai-providers.js mock");
 import { mock } from 'bun:test';
 
-// This is our high-fidelity mock. It provides a fake getModelForTier function
-// that returns a "mock model" with the necessary functions, just like the real one.
+console.log("Loading UPDATED tests/mocks/ai-providers.js mock");
+
+// This mock now mimics the new structure of getModelForTier.
+
+// 1. A mock "language model" object. In tests where generateObject is mocked,
+//    this object is just a placeholder that gets passed along.
+const mockLanguageModel = { type: 'mock-language-model' };
+
+// 2. A mock "client" function. This function would typically be an instance
+//    of createOpenAI, etc. In our mock, it's a function that returns the
+//    placeholder model.
+const mockClient = mock(() => mockLanguageModel);
+
+// 3. The primary mock for getModelForTier. It returns the structure that
+//    the rest of the application now expects.
 export const getModelForTier = mock(() => ({
-  generate: mock().mockResolvedValue({ text: '{}' }),
-  stream: mock().mockResolvedValue({ stream: {} }),
+  client: mockClient,
+  modelName: 'mock-model-name'
 }));
 
 // We also export the other functions from the real module to prevent import errors,
 // but we can just give them simple mock implementations.
 export const _resetProviderInstances = mock();
-export const getExecutionOptions = mock(() => ({}));
-export const selectExecutionMethod = mock(() => 'internal_dev');
-export const validateProviderConfig = mock(() => ({ isValid: true, errors: [], warnings: [] }));
-export const getProviderSummary = mock(() => ({}));
+
+// This mock for getAiProviders returns an object containing our mocked getModelForTier.
 export const getAiProviders = mock(() => ({
-    getModelForTier: getModelForTier
+  getModelForTier: getModelForTier,
+  // We can also mock other functions that might be on the ai provider if needed
+  generateObject: mock((args) => {
+    // A default mock implementation for generateObject if it's not mocked in the test itself
+    console.warn("[Mock AI Provider] generateObject was called but not mocked in the test. Returning empty object.");
+    return Promise.resolve({ object: {} });
+  })
 }));

--- a/tests/unit/tools/business_verification.test.js
+++ b/tests/unit/tools/business_verification.test.js
@@ -10,7 +10,7 @@ describe('Business Verification Tools', () => {
     });
     
     test('generate_financial_projections should use the injected AI functions', async () => {
-        // Create simple, local mocks for the dependencies.
+        // Create mocks that reflect the new { client, modelName } structure.
         const mockGenerateObject = mock().mockResolvedValue({ 
             object: { 
                 projections: [
@@ -19,7 +19,11 @@ describe('Business Verification Tools', () => {
                 summary: "test summary" 
             } 
         });
-        const mockGetModelForTier = mock(() => 'mock-model');
+        const mockClient = mock(() => 'mock-model-from-client');
+        const mockGetModelForTier = mock(() => ({
+          client: mockClient,
+          modelName: 'mock-model-name',
+        }));
 
         const mockAiProvider = {
             getModelForTier: mockGetModelForTier,
@@ -29,14 +33,16 @@ describe('Business Verification Tools', () => {
           { business_plan_content: "test plan", ai: mockAiProvider, generateObject: mockGenerateObject, config: undefined }
         );
 
-        // Assert that our local mocks were called and the result has expected properties.
+        // Assert that our local mocks were called correctly.
         expect(mockGetModelForTier).toHaveBeenCalledWith('b_tier', null, undefined);
+        expect(mockClient).toHaveBeenCalledWith('mock-model-name');
+        expect(mockGenerateObject).toHaveBeenCalledWith(expect.objectContaining({ model: 'mock-model-from-client' }));
         expect(result.projections).toBeDefined();
         expect(result.summary).toBe("test summary");
     });
     
     test('perform_business_valuation should use the injected AI functions', async () => {
-        // Create simple, local mocks for the dependencies.
+        // Create mocks that reflect the new { client, modelName } structure.
         const mockGenerateObject = mock().mockResolvedValue({ 
             object: { 
                 swot_analysis: {
@@ -49,7 +55,11 @@ describe('Business Verification Tools', () => {
                 estimated_value_range: "$1M - $5M"
             } 
         });
-        const mockGetModelForTier = mock(() => 'mock-model');
+        const mockClient = mock(() => 'mock-model-from-client');
+        const mockGetModelForTier = mock(() => ({
+          client: mockClient,
+          modelName: 'mock-model-name',
+        }));
 
         const mockAiProvider = {
             getModelForTier: mockGetModelForTier,
@@ -59,8 +69,10 @@ describe('Business Verification Tools', () => {
           { business_plan_content: "test plan", ai: mockAiProvider, generateObject: mockGenerateObject, config: undefined }
         );
 
-        // Assert that our local mocks were called and the result has expected properties.
+        // Assert that our local mocks were called correctly.
         expect(mockGetModelForTier).toHaveBeenCalledWith('b_tier', null, undefined);
+        expect(mockClient).toHaveBeenCalledWith('mock-model-name');
+        expect(mockGenerateObject).toHaveBeenCalledWith(expect.objectContaining({ model: 'mock-model-from-client' }));
         expect(result.swot_analysis).toBeDefined();
         expect(result.qualitative_valuation).toBe("promising");
     });

--- a/tests/unit/tools/qa_tools.test.js
+++ b/tests/unit/tools/qa_tools.test.js
@@ -11,9 +11,13 @@ describe('QA Tools', () => {
     });
     
     test('verify_requirements should use the injected AI functions', async () => {
-        // Create simple, local mocks for the dependencies.
+        // Create mocks that reflect the new { client, modelName } structure.
         const mockGenerateObject = mock().mockResolvedValue({ object: { passed: true, feedback: 'test feedback' } });
-        const mockGetModelForTier = mock(() => 'mock-model');
+        const mockClient = mock(() => 'mock-model-from-client');
+        const mockGetModelForTier = mock(() => ({
+          client: mockClient,
+          modelName: 'mock-model-name',
+        }));
 
         const mockAiProvider = {
             getModelForTier: mockGetModelForTier,
@@ -23,14 +27,21 @@ describe('QA Tools', () => {
           { requirements: "reqs", code: "code", ai: mockAiProvider, generateObject: mockGenerateObject, config: undefined }
         );
 
-        // Assert that our local mocks were called and the result is correct.
+        // Assert that our local mocks were called correctly.
         expect(mockGetModelForTier).toHaveBeenCalledWith('b_tier', null, undefined);
+        expect(mockClient).toHaveBeenCalledWith('mock-model-name');
+        expect(mockGenerateObject).toHaveBeenCalledWith(expect.objectContaining({ model: 'mock-model-from-client' }));
+        expect(result.passed).toBe(true);
     });
     
     test('verify_architecture should use the injected AI functions', async () => {
-        // Create simple, local mocks for the dependencies.
+        // Create mocks that reflect the new { client, modelName } structure.
         const mockGenerateObject = mock().mockResolvedValue({ object: { passed: false, feedback: 'test feedback' } });
-        const mockGetModelForTier = mock(() => 'mock-model');
+        const mockClient = mock(() => 'mock-model-from-client');
+        const mockGetModelForTier = mock(() => ({
+          client: mockClient,
+          modelName: 'mock-model-name',
+        }));
 
         const mockAiProvider = {
             getModelForTier: mockGetModelForTier,
@@ -40,8 +51,10 @@ describe('QA Tools', () => {
           { architecture_blueprint: "blueprint", code: "code", ai: mockAiProvider, generateObject: mockGenerateObject, config: undefined }
         );
 
-        // Assert that our local mocks were called and the result is correct.
+        // Assert that our local mocks were called correctly.
         expect(mockGetModelForTier).toHaveBeenCalledWith('b_tier', null, undefined);
+        expect(mockClient).toHaveBeenCalledWith('mock-model-name');
+        expect(mockGenerateObject).toHaveBeenCalledWith(expect.objectContaining({ model: 'mock-model-from-client' }));
         expect(result.passed).toBe(false);
     });
 });

--- a/tools/business_verification.js
+++ b/tools/business_verification.js
@@ -4,8 +4,9 @@ import { generateObject as defaultGenerateObject } from "ai";
 import { z } from "zod";
 
 export async function generate_financial_projections({ business_plan_content, ai, generateObject = defaultGenerateObject, config }) {
+  const { client, modelName } = ai.getModelForTier('b_tier', null, config);
   const { object } = await generateObject({
-    model: ai.getModelForTier('b_tier', null, config),
+    model: client(modelName),
     prompt: `Based on the following business plan, generate a simple 5-year financial projection table focusing on Revenue, COGS, OpEx, and Net Profit.`,
     schema: z.object({
       projections: z
@@ -26,8 +27,9 @@ export async function generate_financial_projections({ business_plan_content, ai
 }
 
 export async function perform_business_valuation({ business_plan_content, ai, generateObject = defaultGenerateObject, config }) {
+  const { client, modelName } = ai.getModelForTier('b_tier', null, config);
   const { object } = await generateObject({
-    model: ai.getModelForTier('b_tier', null, config),
+    model: client(modelName),
     prompt: `Analyze the provided business plan and perform a SWOT analysis. Provide a qualitative valuation summary.`,
     schema: z.object({
       swot_analysis: z.object({

--- a/tools/code_intelligence.js
+++ b/tools/code_intelligence.js
@@ -88,8 +88,9 @@ export async function getFullCodebaseContext() {
  */
 export async function validate_tech_stack({ technology, project_goal }, ai, config) {
   const { getModelForTier } = ai;
+  const { client, modelName } = getModelForTier('b_tier', null, config);
   const { object } = await defaultGenerateObject({
-    model: getModelForTier('b_tier', null, config),
+    model: client(modelName),
     prompt: `As a senior solutions architect, analyze the suitability of using "${technology}" for a project with the goal: "${project_goal}".`,
     schema: z.object({
       is_suitable: z.boolean(),

--- a/tools/qa_tools.js
+++ b/tools/qa_tools.js
@@ -362,8 +362,9 @@ export async function verify_comprehensive_quality({ sourceFile, testFile, brief
 // Legacy QA tools for backward compatibility
 
 export async function verify_requirements({ requirements, code, ai, generateObject = defaultGenerateObject, config }) {
+  const { client, modelName } = ai.getModelForTier('b_tier', null, config);
   const { object } = await generateObject({
-    model: ai.getModelForTier('b_tier', null, config),
+    model: client(modelName),
     prompt: `Does the code satisfy all requirements? Respond with a boolean and feedback. Requirements: ${requirements}
 
 Code: ${code}`,
@@ -373,8 +374,9 @@ Code: ${code}`,
 }
 
 export async function verify_architecture({ architecture_blueprint, code, ai, generateObject = defaultGenerateObject, config }) {
+  const { client, modelName } = ai.getModelForTier('b_tier', null, config);
   const { object } = await generateObject({
-    model: ai.getModelForTier('b_tier', null, config),
+    model: client(modelName),
     prompt: `Does the code adhere to the blueprint? Blueprint: ${architecture_blueprint}
 
 Code: ${code}`,

--- a/tools/research.js
+++ b/tools/research.js
@@ -58,8 +58,9 @@ export async function deep_dive({ query, learnings = [], axios = defaultAxios },
         .map((item) => `Source: ${item.url}\n        \n${item.markdown || item.content}`)
         .join("\n        \n---\n        \n");
 
+      const { client, modelName } = getModelForTier('b_tier', null, config);
       const { object } = await ai.generateObject({
-        model: getModelForTier('b_tier', null, config), // Pass config
+        model: client(modelName), // Pass config
         system: await getResearchPrompt(),
         prompt: `Synthesize the key learnings from the following research content. Extract the most critical insights. Additionally, propose 3-5 new, more specific search queries based on what you've just learned.
     ---
@@ -90,8 +91,9 @@ export async function deep_dive({ query, learnings = [], axios = defaultAxios },
   );
   try {
     const client = getFirecrawlClient();
+    const { client: client1, modelName: modelName1 } = getModelForTier('b_tier', null, config);
     const serpGen = await ai.generateObject({
-      model: getModelForTier('b_tier', null, config), // Pass config
+      model: client1(modelName1), // Pass config
       system: await getResearchPrompt(),
       prompt: `You are a research analyst. Based on the primary research goal and the existing learnings, generate a single, highly effective search query to find the next piece of critical information.
     ---
@@ -117,8 +119,9 @@ export async function deep_dive({ query, learnings = [], axios = defaultAxios },
       .map((item) => `Source: ${item.url}\n\n${item.markdown}`)
       .join("\n\n---\n\n");
 
+    const { client: synthesisClient, modelName: synthesisModelName } = getModelForTier('b_tier', null, config);
     const synthesis = await ai.generateObject({
-      model: getModelForTier('b_tier', null, config), // Pass config
+      model: synthesisClient(synthesisModelName), // Pass config
       system: await getResearchPrompt(),
       prompt: `Synthesize the key learnings from the following research content. Extract the most critical insights. Additionally, propose 3-5 new, more specific search queries based on what you've just learned.
     ---
@@ -183,8 +186,9 @@ export async function evaluate_sources({ urls }, ai, config) {
     if (score < 5) {
       try {
         console.log(chalk.yellow(`[Research Tool] Ambiguous URL "${url}". Consulting reasoning_tier LLM for evaluation.`));
+        const { client, modelName } = getModelForTier('reasoning_tier', null, config);
         const { object } = await generateObject({
-          model: getModelForTier('reasoning_tier', null, config),
+          model: client(modelName),
           prompt: `Act as a research librarian. Assess the authority, expertise, and potential biases of the source at this URL: ${url}. Consider the author, publisher, and purpose of the site. Return a credibility score from 0-10 and a brief justification for your score.`,
           schema: evaluationSchema,
         });


### PR DESCRIPTION
Refactors the AI provider logic to align with the recommended pattern for using third-party providers with the Vercel AI SDK.

The `getModelForTier` function in `ai/providers.js` now returns an object containing the provider `client` and the `modelName`, rather than a pre-instantiated model object.

This change makes the interaction with the AI SDK more explicit and robust. All call sites throughout the application and tests have been updated to accommodate this new return structure.

Key changes:
- `ai/providers.js`: `getModelForTier` now returns `{ client, modelName }`.
- All application files using `getModelForTier` have been updated to destructure the result and instantiate the model via `client(modelName)`.
- Unit and integration tests have been updated to use the new mock structure and assertions, ensuring continued test coverage.
- Fixed a variable scope bug in `tools/research.js` that was introduced during the refactoring.