### PR TITLE
Refactor: Eliminate GraphStateManager Singleton

### DIFF
--- a/engine/tool_executor.js
+++ b/engine/tool_executor.js
@@ -18,7 +18,7 @@ import * as mcpCodeSearch from "../tools/mcp_code_search.js";
 import * as superdesignIntegration from "../tools/superdesign_integration.js";
 import * as qwenIntegration from "../tools/qwen_integration.js";
 import * as documentIntelligence from "../tools/document_intelligence.js";
-import * as chatInterface from "../tools/chat_interface.js";
+import { createChatProcessor } from "../tools/chat_interface.js";
 import * as continuousExecution from "../tools/continuous_execution.js";
 import { lightweight_archon_query } from "../services/lightweight_archon.js";
 import { initialize_coderag, semantic_search } from "../services/coderag_integration.js";
@@ -168,7 +168,7 @@ export function createExecutor(engine, ai, config) {
     superdesign: superdesignIntegration,
     qwen_integration: qwenIntegration,
     document_intelligence: documentIntelligence,
-    chat_interface: chatInterface,
+    chat_interface: { process_chat_command: createChatProcessor(engine.stateManager) },
     continuous_execution: continuousExecution,
     lightweight_archon: { query: lightweight_archon_query },
     coderag: { initialize: initialize_coderag, semantic_search },

--- a/src/infrastructure/state/GraphStateManager.js
+++ b/src/infrastructure/state/GraphStateManager.js
@@ -5,7 +5,7 @@ import config from "../../../stigmergy.config.js";
 import path from "path";
 import fs from "fs-extra";
 
-class GraphStateManager extends EventEmitter {
+export class GraphStateManager extends EventEmitter {
   constructor(projectRoot) {
     super();
     this.projectRoot = projectRoot || process.cwd();
@@ -281,7 +281,7 @@ class GraphStateManager extends EventEmitter {
         console.log(`GraphStateManager: Current working directory: ${this.projectRoot}`);
         
         // Ensure the directory exists
-        await fs.ensureDir(stateDir);
+        await fs.mkdir(stateDir, { recursive: true });
         
         // Write the state to the file
         await fs.writeJson(stateFile, state, { spaces: 2 });
@@ -350,7 +350,3 @@ class GraphStateManager extends EventEmitter {
     this.on("stateChanged", callback);
   }
 }
-
-const stateManagerInstance = new GraphStateManager();
-export { GraphStateManager as GraphStateManagerClass }; // Export the class for testing
-export default stateManagerInstance; // Export the singleton instance for the app

--- a/tests/e2e/full_workflow.test.js
+++ b/tests/e2e/full_workflow.test.js
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeAll, afterAll, mock } from 'bun:test';
 import { Engine } from '../../engine/server.js';
-import stateManager from '../../src/infrastructure/state/GraphStateManager.js';
+import { GraphStateManager } from '../../src/infrastructure/state/GraphStateManager.js';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -36,6 +36,7 @@ describe('E2E Workflow (Mock AI)', () => {
             return { text: '', finishReason: 'stop' };
         };
 
+        const stateManager = new GraphStateManager();
         engine = new Engine({ stateManager, _test_streamText: mockStreamText });
         await engine.start();
     });

--- a/tests/e2e/server_lifecycle.test.js
+++ b/tests/e2e/server_lifecycle.test.js
@@ -1,12 +1,14 @@
 import { test, describe, beforeAll, afterAll } from 'bun:test';
 import { Engine } from '../../engine/server.js';
+import { GraphStateManager } from '../../src/infrastructure/state/GraphStateManager.js';
 
 describe('Server Lifecycle', () => {
   let engine;
 
   beforeAll(async () => {
     process.env.STIGMERGY_PORT = 3018;
-    engine = new Engine();
+    const stateManager = new GraphStateManager();
+    engine = new Engine({ stateManager });
     await engine.start();
   });
 


### PR DESCRIPTION
This commit refactors the `GraphStateManager` to eliminate the singleton pattern that was causing tests to hang.

- The `GraphStateManager` module now exports a class instead of a singleton instance.
- The `Engine` class now requires a `stateManager` instance to be passed to its constructor (dependency injection).
- All consumers of the `GraphStateManager` have been updated to use the new dependency injection pattern, including:
  - `engine/server.js`
  - `engine/tool_executor.js`
  - `tools/chat_interface.js`
- Unit and E2E tests have been updated to correctly provide the `GraphStateManager` dependency.

This change resolves a critical architectural issue where multiple, independent state managers were being created, leading to dangling processes that prevented the test suite from completing. The tests now run to completion, though some downstream failures caused by the refactoring remain.