### PR TITLE
Fix: Resolve E2E test timeout by isolating server process

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
 import { upgradeWebSocket } from 'hono/bun';
+import { cors } from 'hono/cors';
 import chalk from 'chalk';
 import { GraphStateManager } from "../src/infrastructure/state/GraphStateManager.js";
 import { createExecutor } from "./tool_executor.js";
@@ -17,6 +18,7 @@ export class Engine {
             throw new Error("Engine requires a stateManager instance on construction.");
         }
         this.app = new Hono();
+        this.app.use('*', cors());
         this.projectRoot = options.projectRoot || process.cwd();
         this.stateManager = options.stateManager;
         this.clients = new Set();

--- a/tests/e2e/mock_server.js
+++ b/tests/e2e/mock_server.js
@@ -1,0 +1,50 @@
+import { Engine } from '../../engine/server.js';
+import { GraphStateManager } from '../../src/infrastructure/state/GraphStateManager.js';
+
+// This is the "script" for our mock AI's conversation.
+const mockStreamText = async ({ messages }) => {
+    const lastMessage = messages[messages.length - 1];
+    const prompt = lastMessage.role === 'user' ? lastMessage.content : `[Received tool result for ${lastMessage.tool_name}]`;
+
+    if (prompt.includes('create the initial `plan.md`')) {
+        return { toolCalls: [{ toolCallId: 'c1', toolName: 'stigmergy.task', args: { subagent_type: '@qa', description: 'Please review...' } }], finishReason: 'tool-calls' };
+    }
+    if (prompt.includes('Please review')) {
+        // 2. @tools/qa_tools.js is triggered, approves the plan by DELEGATING to the dispatcher.
+        return {
+            toolCalls: [{ toolCallId: 'c_qa_approve', toolName: 'stigmergy.task', args: { subagent_type: '@dispatcher', description: 'The plan has been approved. Begin executing the tasks in plan.md.' } }],
+            finishReason: 'tool-calls'
+        };
+    }
+    if (prompt.includes('Begin executing')) {
+        return { toolCalls: [{ toolCallId: 'c3', toolName: 'file_system.writeFile', args: { path: 'src/output.js', content: 'Hello World' } }], finishReason: 'tool-calls' };
+    }
+    if (lastMessage.tool_name === 'file_system.writeFile') {
+        return { toolCalls: [{ toolCallId: 'c4', toolName: 'system.updateStatus', args: { newStatus: 'EXECUTION_COMPLETE' } }], finishReason: 'tool-calls' };
+    }
+    return { text: '', finishReason: 'stop' };
+};
+
+const stateManager = new GraphStateManager();
+const engine = new Engine({ stateManager, _test_streamText: mockStreamText });
+
+console.log('Starting mock server...');
+engine.start().then(() => {
+    console.log('Mock server started successfully.');
+}).catch(err => {
+    console.error('Failed to start mock server:', err);
+    process.exit(1);
+});
+
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+    console.log('SIGINT received. Shutting down mock server...');
+    await engine.stop();
+    process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+    console.log('SIGTERM received. Shutting down mock server...');
+    await engine.stop();
+    process.exit(0);
+});


### PR DESCRIPTION
The E2E test in `tests/e2e/full_workflow.test.js` was timing out due to a suspected deadlock in the `bun test` runner when a test file also manages a server process with WebSockets.

This commit resolves the issue by implementing a robust workaround:
- The server is now launched in a separate child process using `Bun.spawn()`, decoupling its lifecycle from the test runner.
- A new `tests/e2e/mock_server.js` script is created to act as the entrypoint for this test server.
- The E2E test now performs a health check to ensure the server is ready before running the test and terminates the child process in `afterAll`.
- The Hono server is configured with CORS middleware to allow the test client to connect.
- The test port is changed to 3011 to avoid potential `EADDRINUSE` conflicts.

This change makes the E2E test stable and reliable.