### PR TITLE
Fix(agent): Prevent infinite loop by correcting agent protocol

### DIFF
--- a/.stigmergy-core/agents/specifier.md
+++ b/.stigmergy-core/agents/specifier.md
@@ -19,7 +19,7 @@ agent:
       - `status`: Always set to `PENDING` initially.
       - `dependencies`: A list of `id`s of other tasks that must be completed first. For the first task, this will be an empty list `[]`.
       - `files_to_create_or_modify`: A list of file paths that will be affected by this task."
-    - "REVIEW_HANDOFF_PROTOCOL: After generating the plan, my final action MUST be a single tool call to `stigmergy.task`. The `subagent_type` must be '@qa' and the `description` must be 'Please review this draft plan.md for clarity, completeness, and potential edge cases. The draft content is as follows: [DRAFT_CONTENT_HERE]'."
+    - "SAVE_AND_HANDOFF_PROTOCOL: After generating the plan content, I will first save it to a file named `plan.md` in my working directory using the `file_system.writeFile` tool. My final action MUST then be a single tool call to `stigmergy.task`. The `subagent_type` for this task must be '@qa' and the `description` must be 'Please review the plan located at `plan.md` for clarity, completeness, and potential edge cases.'"
   engine_tools:
     - "stigmergy.task"
     - "file_system.*"

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "react-syntax-highlighter": "^5.8.0",
         "recharts": "^3.2.0",
         "similarity": "^1.2.1",
+        "ws": "^8.18.3",
         "zod": "^3.22.4",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-syntax-highlighter": "^5.8.0",
     "recharts": "^3.2.0",
     "similarity": "^1.2.1",
+    "ws": "^8.18.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The `send_prompt.js` script was timing out because the `@specifier` agent was getting stuck in an infinite loop.

The agent's `REVIEW_HANDOFF_PROTOCOL` instructed it to embed the entire multi-line `plan.md` content directly into a tool call's string argument. This frequently caused formatting errors when interacting with a live LLM, leading to a failed tool call. The agent would then retry the same failed step, causing a loop that would only terminate when the engine's `maxTurns` limit was reached.

This commit fixes the issue by changing the protocol to a more robust file-based handoff:
1.  The agent now first saves the generated plan to a `plan.md` file using the `file_system.writeFile` tool.
2.  It then calls the next agent (`@qa`) with a simple message referencing the file path, avoiding any complex string escaping issues.

Additionally, a `.env.development` file has been added and configured to use the mock AI, which facilitates local testing and validation of scripts like `send_prompt.js` without requiring live API keys. The `ws` dependency, required by this script, has also been added.