### PR TITLE
feat: Integrate React dashboard with Hono server

### DIFF
--- a/tests/e2e/full_workflow.test.js
+++ b/tests/e2e/full_workflow.test.js
@@ -5,7 +5,8 @@ import fs from 'fs-extra';
 import WebSocket from 'ws';
 
 const E2E_TIMEOUT = 30000;
-const PORT = 3019; // Use a different port to avoid conflicts
+// Use a random port in the ephemeral range to avoid EADDRINUSE errors in CI
+const PORT = Math.floor(Math.random() * (65535 - 49152) + 49152);
 const serverUrl = `ws://localhost:${PORT}/ws`;
 const healthCheckUrl = `http://localhost:${PORT}/`;
 const originalCwd = process.cwd();


### PR DESCRIPTION
Refactors the server to correctly serve the static React Dashboard application and handle its API and WebSocket connections using the Hono framework.

- Replaces the old Express-based router in `engine/dashboard.js` with a new, Hono-native middleware using `serveStatic`.
- Integrates the new dashboard app into the main `engine/server.js` by mounting it on the root route.
- Adds a `POST /mcp` endpoint to `engine/server.js` for integration with IDEs like continue.dev.
- Updates integration tests to correctly mock the filesystem (`fs` and `fs-extra`) to prevent `serveStatic` errors.
- Fixes E2E test instability by using a random port and a robust `notFound` handler for the SPA fallback.