### PR TITLE
fix: Resolve dashboard 404 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ Integrate Stigmergy directly into your VS Code workflow using the `continue.dev`
 
     ```json
     {
-      "models": [
-        {
-          "title": "Stigmergy",
-          "provider": "custom",
-          "model": "stigmergy-mcp",
-          "apiKey": "EMPTY",
-          "apiBase": "http://localhost:3010/mcp"
-        }
-      ]
+        "models": [
+            {
+                "title": "Stigmergy",
+                "provider": "openai-compatible",
+                "model": "stigmergy-mcp",
+                "apiKey": "EMPTY",
+                "apiBase": "http://localhost:3010/mcp"
+            }
+        ]
     }
     ```
     *   `apiBase`: This must point to the `/mcp` (Master Control Protocol) endpoint of your running Stigmergy engine.

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stigmergy Dashboard</title>
+    <link rel="stylesheet" href="/index.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/index.js"></script>
+</body>
+</html>

--- a/dashboard/public/index.js
+++ b/dashboard/public/index.js
@@ -24010,14 +24010,14 @@ var import_react5 = __toESM(require_react(), 1);
 
 // dashboard/src/hooks/useWebSocket.js
 var import_react = __toESM(require_react(), 1);
-var useWebSocket = () => {
+var useWebSocket = (url) => {
   const [data, setData] = import_react.useState(null);
   const [error, setError] = import_react.useState(null);
   const [loading, setLoading] = import_react.useState(true);
   const ws = import_react.useRef(null);
   import_react.useEffect(() => {
-    const url = process.env.REACT_APP_WEBSOCKET_URL || "ws://localhost:3010";
-    ws.current = new WebSocket(url);
+    const wsUrl = url || process.env.REACT_APP_WEBSOCKET_URL || "ws://localhost:3010/ws";
+    ws.current = new WebSocket(wsUrl);
     ws.current.onopen = () => {
       console.log(`WebSocket connection opened to ${url}`);
       setLoading(false);

--- a/dashboard/src/hooks/useWebSocket.js
+++ b/dashboard/src/hooks/useWebSocket.js
@@ -1,15 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
 
-const useWebSocket = () => {
+const useWebSocket = (url) => {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
   const ws = useRef(null);
 
   useEffect(() => {
-    const url = process.env.REACT_APP_WEBSOCKET_URL || 'ws://localhost:3010';
+    const wsUrl = url || process.env.REACT_APP_WEBSOCKET_URL || 'ws://localhost:3010/ws';
     // Create WebSocket connection
-    ws.current = new WebSocket(url);
+    ws.current = new WebSocket(wsUrl);
 
     ws.current.onopen = () => {
       console.log(`WebSocket connection opened to ${url}`);


### PR DESCRIPTION
- Adds a missing index.html to the dashboard's public directory to resolve the 404 error when loading the application.
- Fixes the WebSocket connection URL in the useWebSocket hook, allowing the dashboard to render correctly.
- Updates the README.md with the correct 'openai-compatible' provider configuration for the continue.dev extension.