### PR TITLE
Fix(server): Implement OpenAI-compatible SSE for IDE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,18 @@ Integrate Stigmergy directly into your VS Code workflow using the `continue.dev`
 
     ```json
     {
-        "models": [
-            {
-                "title": "Stigmergy",
-                "provider": "openai-compatible",
-                "model": "stigmergy-mcp",
-                "apiKey": "EMPTY",
-                "apiBase": "http://localhost:3010/mcp"
-            }
-        ]
+      "models": [
+        {
+          "title": "Stigmergy",
+          "provider": "openai-compatible",
+          "model": "stigmergy-mcp",
+          "apiKey": "EMPTY",
+          "apiBase": "http://localhost:3010/mcp"
+        }
+      ]
     }
     ```
-    *   `apiBase`: This must point to the `/mcp` (Master Control Protocol) endpoint of your running Stigmergy engine.
+    *   `apiBase`: This must point to the `/mcp` (Model-Context Protocol) endpoint of your running Stigmergy engine. The `openai-compatible` provider in `continue.dev` will automatically append the necessary path, so ensure you do not add a trailing slash.
 
 3.  **Reload VS Code & Start Developing:**
     Reload your VS Code window. The "Stigmergy" model will now be available in the `continue.dev` panel. When you send a prompt, `continue.dev` will automatically include the active project path in its request to the engine. You can monitor all agent activity in real-time on your dashboard.


### PR DESCRIPTION
Refactors the `/mcp` endpoint in `engine/server.js` to provide a compliant Server-Sent Events (SSE) stream for `openai-compatible` clients like the `continue.dev` VS Code extension.

The previous implementation used `c.streamText`, which sent raw JSON objects and was not parsable by the client. This change replaces it with `c.streamSSE` and formats each message to match the OpenAI Chat Completions API chunk structure. This resolves the connection failure and enables seamless integration with the IDE.

Additionally, this commit clarifies the `continue.dev` setup instructions in `README.md` to prevent common configuration errors.