### PR TITLE
feat: Implement CLI-first universal bridge

### DIFF
--- a/.stigmergy-core/agents/qoder.md
+++ b/.stigmergy-core/agents/qoder.md
@@ -1,0 +1,23 @@
+```yaml
+agent:
+  id: "qoder"
+  alias: "@qoder"
+  name: "Qoder Integration Agent"
+  archetype: "Integrator"
+  title: "Qoder CLI Bridge"
+  icon: "🔌"
+  is_interface: true
+  model_tier: "reasoning_tier"
+  persona:
+    role: "An interface agent that bridges the Qoder IDE with the Stigmergy CLI."
+    style: "Direct and efficient."
+    identity: "I am the Qoder agent. I receive a high-level goal and execute it using the `stigmergy run` command."
+  core_protocols:
+    - |
+      My purpose is to act as a bridge for the Qoder IDE. When I receive a prompt, I will:
+      1.  Take the user's input as the goal.
+      2.  Use the `shell.run` tool to execute the command: `stigmergy run --goal "THE_USER_GOAL"`, replacing "THE_USER_GOAL" with the prompt I received.
+      3.  Stream the output of the command back to the user.
+  engine_tools:
+    - "shell.run"
+```

--- a/README.md
+++ b/README.md
@@ -105,33 +105,50 @@ This guide will walk you through setting up the Stigmergy engine, connecting the
     *   Enter the **full, absolute path** to your project's directory.
     *   Click **"Set Active Project"**. The dashboard will update to show your selected project, and the engine is now ready to work on it.
 
-### **Step 3: Connect Your IDE (continue.dev)**
+### **Step 3: Connect Your IDE (The New CLI-First Way)**
 
-Integrate Stigmergy directly into your VS Code workflow using the `continue.dev` extension.
+Our new CLI-first approach simplifies IDE integration. Instead of complex model configurations, you now use a simple command.
+
+#### **For `continue.dev` (VS Code)**
 
 1.  **Install `continue.dev`:**
     If you haven't already, install the [continue.dev extension](https://marketplace.visualstudio.com/items?itemName=Continue.continue) from the VS Code Marketplace.
 
-2.  **Configure `continue.dev`:**
-    Open (or create) your `continue.dev` configuration file. This is typically located at `~/.continue/config.json` or within your project's `.continue/config.json` file. Add the following `CustomLLM` configuration to the `models` array:
+2.  **Configure a Slash Command:**
+    Open your `continue.dev` configuration file (`~/.continue/config.json` or `.continue/config.json`) and add the following to the `slashCommands` array:
 
     ```json
     {
-      "models": [
+      "slashCommands": [
         {
-          "title": "Stigmergy",
-          "provider": "openai-compatible",
-          "model": "stigmergy-mcp",
-          "apiKey": "EMPTY",
-          "apiBase": "http://localhost:3010/mcp"
+          "name": "stigmergy",
+          "description": "Run a Stigmergy mission",
+          "options": {
+            "command": "stigmergy run --goal \"{{{ input }}}\""
+          }
         }
       ]
     }
     ```
-    *   `apiBase`: This must point to the `/mcp` (Model-Context Protocol) endpoint of your running Stigmergy engine. The `openai-compatible` provider in `continue.dev` will automatically append the necessary path, so ensure you do not add a trailing slash.
 
-3.  **Reload VS Code & Start Developing:**
-    Reload your VS Code window. The "Stigmergy" model will now be available in the `continue.dev` panel. When you send a prompt, `continue.dev` will automatically include the active project path in its request to the engine. You can monitor all agent activity in real-time on your dashboard.
+3.  **Usage:**
+    In the `continue.dev` input box, type `/stigmergy` followed by your goal. For example:
+    ```
+    /stigmergy Fix the authentication bug
+    ```
+    This will execute the command directly in your integrated terminal, and you will see the mission status streamed live.
+
+#### **For Qoder, Cursor, Trae, and any other IDE**
+
+The beauty of the CLI-first approach is its universality. For any IDE with a built-in terminal:
+
+1.  **Open the Terminal:** Open your IDE's integrated terminal.
+2.  **Navigate to Your Project:** `cd /path/to/your/project`
+3.  **Run the Command:**
+    ```bash
+    stigmergy run --goal "Your high-level objective here"
+    ```
+    The mission status will be streamed directly into your terminal, providing a universal and reliable integration for any development environment.
 
 ### **Step 4: Run Tests**
 To ensure everything is working correctly, run the full test suite:

--- a/cli/commands/run.js
+++ b/cli/commands/run.js
@@ -1,0 +1,75 @@
+import WebSocket from 'ws';
+import chalk from 'chalk';
+import ora from 'ora';
+
+export const command = 'run';
+export const desc = 'Run a new mission with a specified goal';
+export const builder = {
+  goal: {
+    alias: 'g',
+    describe: 'The high-level goal for the mission',
+    demandOption: true,
+    type: 'string',
+  },
+};
+
+export const handler = async (argv) => {
+  const { goal } = argv;
+  const project_path = process.cwd();
+  const spinner = ora('Connecting to Stigmergy Engine...').start();
+
+  const ws = new WebSocket('ws://localhost:3010/ws');
+
+  ws.on('open', () => {
+    spinner.succeed('Connected to Stigmergy Engine.');
+    console.log(chalk.blue(`🚀 Starting mission with goal: "${goal}"`));
+
+    const message = {
+      type: 'start_mission',
+      payload: {
+        goal,
+        project_path,
+      },
+    };
+    ws.send(JSON.stringify(message));
+    spinner.start('Mission in progress...');
+  });
+
+  ws.on('message', (data) => {
+    try {
+      const message = JSON.parse(data);
+      if (message.type === 'state_update') {
+        const { project_status, message: statusMessage } = message.payload;
+        spinner.text = `[${project_status}] ${statusMessage || ''}`;
+
+        if (project_status === 'EXECUTION_COMPLETE' || project_status === 'COMPLETED' || project_status === 'PLAN_EXECUTED' || project_status === 'ERROR') {
+          if (project_status === 'ERROR') {
+            spinner.fail(chalk.red(`Mission failed: ${project_status}`));
+          } else {
+            spinner.succeed(chalk.green(`Mission finished with status: ${project_status}`));
+          }
+          ws.close();
+        }
+      } else if (message.type === 'project_switched') {
+          spinner.info(`Engine context switched to: ${message.payload.path}`);
+      } else {
+        // Fallback for any other message type
+        console.log(chalk.gray(data.toString()));
+      }
+    } catch (error) {
+      console.error(chalk.red('Error processing message from engine:'), error);
+      console.log(chalk.gray('Raw message:', data.toString()));
+    }
+  });
+
+  ws.on('close', () => {
+    if (spinner.isSpinning) {
+        spinner.succeed('Disconnected from Stigmergy Engine.');
+    }
+  });
+
+  ws.on('error', (error) => {
+    spinner.fail(chalk.red('Connection to Stigmergy Engine failed. Is the service running?'));
+    console.error(chalk.red(error.message));
+  });
+};

--- a/cli/index.js
+++ b/cli/index.js
@@ -15,6 +15,7 @@ const coreBackup = new CoreBackup();
 
 // Define available commands for suggestions
 const availableCommands = [
+  'run',
   'start',
   'start --power',
   'init',
@@ -296,6 +297,25 @@ enter Stigmergy commands without the "stigmergy" prefix.
 Type "help" within the interactive mode to see available commands.
   `);
 
+program
+  .command("run")
+  .description("Run a new mission with a specified goal.")
+  .option('-g, --goal <goal>', 'The high-level goal for the mission')
+  .action(async (options) => {
+    const runPath = path.resolve(__dirname, './commands/run.js');
+    const { handler } = await import(runPath);
+    // Commander passes the options object directly, which matches the 'argv' expected by the yargs-style handler.
+    await handler(options);
+  })
+  .addHelpText('after', `
+Examples:
+  $ stigmergy run --goal "Fix the authentication bug"
+  $ stigmergy run -g "Implement feature X"
+
+This command sends a goal to the running Stigmergy service
+and streams the mission status back to the terminal.
+  `);
+
 // Override the default help command to add examples
 program.addHelpText('after', `
 Examples:
@@ -313,7 +333,7 @@ async function main() {
     const command = process.argv[2];
     // The guardian check should only run if a stigmergy command that REQUIRES a core is run.
     // 'init', 'start-service', 'stop-service', 'service-status' do not require one to exist beforehand.
-    const commandsWithoutGuardian = ["init", "start-service", "stop-service", "service-status", "interactive"];
+    const commandsWithoutGuardian = ["run", "init", "start-service", "stop-service", "service-status", "interactive"];
     if (command && !commandsWithoutGuardian.includes(command)) {
       if (!await runGuardianCheck()) {
         process.exit(1);

--- a/engine/server.js
+++ b/engine/server.js
@@ -316,7 +316,12 @@ export class Engine {
                 onMessage: async (evt, ws) => {
                     try {
                         const data = JSON.parse(evt.data);
-                        if (data.type === 'user_chat_message') {
+                        if (data.type === 'start_mission') {
+                            const { goal, project_path } = data.payload;
+                            console.log(chalk.blue(`[WebSocket] Received start_mission for project: ${project_path}`));
+                            await this.setActiveProject(project_path);
+                            await this.executeGoal(goal);
+                        } else if (data.type === 'user_chat_message') {
                             await this.executeGoal(data.payload.prompt);
                         } else if (data.type === 'set_project') {
                             await this.setActiveProject(data.payload.path);


### PR DESCRIPTION
This commit introduces a new 'CLI-First' strategy for IDE integration, replacing the previous fragile approach. A new `stigmergy run --goal` command serves as the single entry point for all autonomous tasks.

- Creates a new `stigmergy run` command in `cli/commands/run.js` that connects to the engine via WebSocket and sends a `start_mission` message.
- Updates the engine's WebSocket server in `engine/server.js` to handle the `start_mission` message, setting the active project and executing the goal.
- Updates the main CLI entry point `cli/index.js` to include the new `run` command.
- Creates a new Qoder agent definition in `.stigmergy-core/agents/qoder.md` to use the new CLI command.
- Updates `README.md` with new instructions for `continue.dev` using `slashCommands` and a universal guide for other IDEs to use the terminal.